### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Use local my-action
         uses: ./.github/actions/local
       - name: In with
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: lgohr/test-push
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore